### PR TITLE
Update networkx version to stay with v2.3

### DIFF
--- a/modules/InferenceModule/Dockerfile.amd64
+++ b/modules/InferenceModule/Dockerfile.amd64
@@ -15,7 +15,7 @@ RUN pip install --upgrade pip
  
 RUN pip install azure-storage && \
     pip install flask opencv-python && \
-    pip install pytz defusedxml networkx
+    pip install pytz defusedxml networkx==2.3
 
 # Expose the port
 EXPOSE 5000


### PR DESCRIPTION
Perf regression using latest (v2.4) networkx package. Forcing to stay with v2.3 package.